### PR TITLE
Eloss and propagator

### DIFF
--- a/core/include/AbsTrackRep.h
+++ b/core/include/AbsTrackRep.h
@@ -274,6 +274,10 @@ class AbsTrackRep : public TObject {
   //! Get the charge of the particle of the pdg code
   double getPDGCharge() const;
 
+
+  //! Get the jacobian between two extrapolating plane (added by Abi for E1039)
+  virtual TMatrixD getJacobian() const = 0;
+
   /**
    * @brief Get the (fitted) charge of a state.
    * This is not always equal the pdg charge (e.g. if the charge sign was flipped during the fit).

--- a/trackReps/include/RKTrackRep.h
+++ b/trackReps/include/RKTrackRep.h
@@ -138,6 +138,8 @@ class RKTrackRep : public AbsTrackRep {
       bool stopAtBoundary = false,
       bool calcJacobianNoise = false) const override;
 
+  //@Get the jacobian between two extrapolating plane (added by Abi for E1039)
+  virtual TMatrixD getJacobian() const override {return fJacobian_;}
 
   unsigned int getDim() const override {return 5;}
 

--- a/trackReps/src/MaterialEffects.cc
+++ b/trackReps/src/MaterialEffects.cc
@@ -484,7 +484,14 @@ double MaterialEffects::dEdxBetheBloch(double betaSquare, double gamma, double g
   double massRatio( me_ / mass_ );
   double argument( gammaSquare * betaSquare * me_ * 1.E3 * 2. / ((1.E-6 * mEE_) *
       sqrt(1. + 2. * gamma * massRatio + massRatio * massRatio)) );
-  result *= log(argument) - betaSquare; // Bethe-Bloch [MeV/cm]
+  //  result *= log(argument) - betaSquare; // Bethe-Bloch [MeV/cm]
+
+//@Density correction term implemented for the Iron; by Abi (E1039 experiment)
+  double mom = gamma*mass_*sqrt(betaSquare);
+  double density_correction = 0; /// 0 unless Z=26 (Fe) at present.
+  if (matZ_ == 26) density_correction = 0.5 *(2.*2.303*log10(mom/mass_)-4.2991+0.1468*pow((3.1531-log10(mom/mass_)),2.9632));
+  result *= log(argument) - betaSquare - density_correction; // Bethe-Bloch [MeV/cm]
+
   result *= 1.E-3;  // in GeV/cm, hence 1.e-3
   if (result < 0.) {
     result = 0;


### PR DESCRIPTION
In this pull request, I have added the density correction term for Fe in the Bethe Bloch expression of energy loss. Also, added interface functions to get the Jacobean (propagator) between two extrapolating planes. 